### PR TITLE
force encoding

### DIFF
--- a/app/views/deliveries/show.html.haml
+++ b/app/views/deliveries/show.html.haml
@@ -108,7 +108,7 @@
         %pre= @delivery.text_part
     - elsif @delivery.html_part
       %div.tab-pane.active#html
-        .well= @delivery.html_part.html_safe
+        .well= @delivery.html_part.html_safe.force_encoding("UTF-8")
     - else
       %div.tab-pane.active#text
         %pre= @delivery.text_part


### PR DESCRIPTION
this because, when u send an email with special charset the app fail with the following message:

incompatible character encodings: UTF-8 and ASCII-8BIT

and force_encoding fix this issue
