### PR TITLE
Fix: mpapis@gmail.com has no key at gnupg.net, but at mit.edu

### DIFF
--- a/provisioning/roles/rvm_io.rvm1-ruby/defaults/main.yml
+++ b/provisioning/roles/rvm_io.rvm1-ruby/defaults/main.yml
@@ -31,4 +31,4 @@ rvm1_rvm_check_for_updates: True
 rvm1_gpg_keys: 'D39DC0E3'
 
 # The GPG key server
-rvm1_gpg_key_server: 'hkp://keys.gnupg.net'
+rvm1_gpg_key_server: 'hkp://pgp.mit.edu'


### PR DESCRIPTION
You ask for a key that doesn't exist on gnupg.net