### PR TITLE
Gracefully handle unrecognised Postfix log lines

### DIFF
--- a/app/models/postfix_log_line.rb
+++ b/app/models/postfix_log_line.rb
@@ -34,6 +34,8 @@ class PostfixLogLine < ActiveRecord::Base
 
   def self.create_from_line(line)
     values = match_main_content(line)
+    return if values.nil?
+
     program = values.delete(:program)
     to = values.delete(:to)
     queue_id = values.delete(:queue_id)
@@ -57,6 +59,11 @@ class PostfixLogLine < ActiveRecord::Base
     # Assume the log file was written using syslog and parse accordingly
     p = SyslogProtocol.parse("<13>" + line)
     content_match = p.content.match /^postfix\/(\w+)\[(\d+)\]: (([0-9A-F]+): )?(.*)/
+    if content_match.nil?
+      puts "Skipping unrecognised line: #{line}"
+      return nil
+    end
+
     program_content = content_match[5]
     to_match = program_content.match(/to=<([^>]+)>/)
     relay_match = program_content.match(/relay=([^,]+)/)

--- a/spec/models/postfix_log_line_spec.rb
+++ b/spec/models/postfix_log_line_spec.rb
@@ -5,6 +5,7 @@ describe PostfixLogLine do
   let(:line2) { "Apr  5 18:41:58 kedumba postfix/qmgr[2638]: E69DB36D4A2B: removed" }
   let(:line3) { "Apr  5 17:11:07 kedumba postfix/smtpd[7453]: connect from unknown[111.142.251.143]" }
   let(:line4) { "Apr  5 14:21:51 kedumba postfix/smtp[2500]: 39D9336AFA81: to=<anincorrectemailaddress@openaustralia.org>, relay=aspmx.l.google.com[173.194.79.27]:25, delay=1, delays=0.08/0/0.58/0.34, dsn=5.1.1, status=bounced (host aspmx.l.google.com[173.194.79.27] said: 550-5.1.1 The email account that you tried to reach does not exist. zb4si15321910pbb.132 - gsmtp (in reply to RCPT TO command))" }
+  let(:line5) { "Oct 25 17:36:47 vps331845 postfix[6084]: Postfix is running with backwards-compatible default setting" }
 
   context "one log line" do
     let (:l) do
@@ -156,6 +157,13 @@ describe PostfixLogLine do
         expect(delivery1.postfix_log_lines).to be_empty
         expect(delivery2.postfix_log_lines.count).to eq 1
       end
+    end
+
+    it "should log and skip unrecognised lines" do
+      expect(PostfixLogLine).to receive(:puts).with("Skipping unrecognised line: Oct 25 17:36:47 vps331845 postfix[6084]: Postfix is running with backwards-compatible default setting")
+      email = FactoryGirl.create(:email)
+      result = PostfixLogLine.create_from_line(line5)
+      expect(result).to be_nil
     end
   end
 


### PR DESCRIPTION
This changes the log daemon to gracefully handle unrecognised Postfix log lines. For example, when setting up Postfix with the default settings on Ubuntu 16.04 it will log the following:

```
Oct 25 17:36:47 vps331845 postfix[6084]: Postfix is running with backwards-compatible default settings
Oct 25 17:36:47 vps331845 postfix[6084]: See http://www.postfix.org/COMPATIBILITY_README.html for details
Oct 25 17:36:47 vps331845 postfix[6084]: To disable backwards compatibility use "postconf compatibility_level=2" and "postfix reload"
```

This causes the log daemon to crash with `NoMethodError: undefined method '[]' for nil:NilClass`.

This commit lets the log demon handle invalid lines, they will be logged to STDOUT and skipped. It should fix #249 too.
