### PR TITLE
Manage blacklist when delivery missing

### DIFF
--- a/app/models/black_list.rb
+++ b/app/models/black_list.rb
@@ -1,4 +1,8 @@
 class BlackList < ActiveRecord::Base
   belongs_to :address
   belongs_to :caused_by_delivery, class_name: "Delivery"
+
+  def has_record_of_cause?
+    caused_by_delivery.present? && caused_by_delivery.subject.present?
+  end
 end

--- a/app/views/addresses/to.html.haml
+++ b/app/views/addresses/to.html.haml
@@ -8,11 +8,13 @@
     = @address.text
     is on the blacklist
   %p
-    - unless @address.blacklist(current_admin.team).caused_by_delivery.subject.blank?
+    - if @address.blacklist(current_admin.team).caused_by_delivery && @address.blacklist(current_admin.team).caused_by_delivery.subject.present?
       Reason:
       = link_to truncate(@address.blacklist(current_admin.team).caused_by_delivery.postfix_log_lines.first.extended_status, length: 160), @address.blacklist(current_admin.team).caused_by_delivery
       = time_ago_in_words(@address.blacklist(current_admin.team).caused_by_delivery.postfix_log_lines.first.created_at)
       ago
+    - else
+      We don't know why this was blacklisted. The delivery that caused it may have been archived.
 
   - if policy(@address.blacklist(current_admin.team)).destroy?
     = button_to "Remove from blacklist", @address.blacklist(current_admin.team), method: :delete, class: "btn btn-danger"

--- a/app/views/addresses/to.html.haml
+++ b/app/views/addresses/to.html.haml
@@ -8,7 +8,7 @@
     = @address.text
     is on the blacklist
   %p
-    - if @address.blacklist(current_admin.team).caused_by_delivery && @address.blacklist(current_admin.team).caused_by_delivery.subject.present?
+    - if @address.blacklist(current_admin.team).has_record_of_cause?
       Reason:
       = link_to truncate(@address.blacklist(current_admin.team).caused_by_delivery.postfix_log_lines.first.extended_status, length: 160), @address.blacklist(current_admin.team).caused_by_delivery
       = time_ago_in_words(@address.blacklist(current_admin.team).caused_by_delivery.postfix_log_lines.first.created_at)

--- a/app/views/black_lists/index.html.haml
+++ b/app/views/black_lists/index.html.haml
@@ -19,7 +19,7 @@
           %tr
             %td= black_list.address.text
             %td
-              - if black_list.caused_by_delivery && black_list.caused_by_delivery.subject.present?
+              - if black_list.has_record_of_cause?
                 = link_to truncate(black_list.caused_by_delivery.postfix_log_lines.first.extended_status, length: 160), black_list.caused_by_delivery
               - else
                 We don't know why this was blacklisted. The delivery that caused it may have been archived.

--- a/app/views/black_lists/index.html.haml
+++ b/app/views/black_lists/index.html.haml
@@ -19,11 +19,14 @@
           %tr
             %td= black_list.address.text
             %td
-              - unless black_list.caused_by_delivery.subject.blank?
+              - if black_list.caused_by_delivery && black_list.caused_by_delivery.subject.present?
                 = link_to truncate(black_list.caused_by_delivery.postfix_log_lines.first.extended_status, length: 160), black_list.caused_by_delivery
+              - else
+                We don't know why this was blacklisted. The delivery that caused it may have been archived.
             %td
-              = time_ago_in_words(black_list.caused_by_delivery.postfix_log_lines.first.created_at)
-              ago
+              - if black_list.caused_by_delivery
+                = time_ago_in_words(black_list.caused_by_delivery.postfix_log_lines.first.created_at)
+                ago
             - if policy(black_list).destroy?
               %td
                 = button_to "Remove", black_list, method: :delete, class: "btn btn-danger"

--- a/spec/factories/black_lists.rb
+++ b/spec/factories/black_lists.rb
@@ -2,6 +2,7 @@
 
 FactoryGirl.define do
   factory :black_list do
+    team_id 1
     address_id 1
     caused_by_delivery_id 1
   end

--- a/spec/models/black_list_spec.rb
+++ b/spec/models/black_list_spec.rb
@@ -1,4 +1,33 @@
 require 'spec_helper'
 
 describe BlackList do
+  describe "#has_record_of_black_list_cause?" do
+    context "when the caused_by_delivery is missing" do
+      let(:black_list) { create(:black_list, caused_by_delivery: nil ) }
+
+      it { expect(black_list.has_record_of_cause?).to be false }
+    end
+
+    context "when the caused_by_delivery present but has no subject" do
+      let(:black_list) do
+        delivery = create(:delivery, email: create(:email, subject: nil))
+        create(:black_list, caused_by_delivery: delivery)
+      end
+
+      it { expect(black_list.has_record_of_cause?).to be false }
+    end
+
+    context "when the caused_by_delivery present and has a subject" do
+      let(:delivery) { create(:delivery) }
+      let(:black_list) { create(:black_list, caused_by_delivery: delivery) }
+
+      before do
+        allow(delivery).to receive(:subject).and_return("foo")
+      end
+
+      it do
+        expect(black_list.has_record_of_cause?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/mlandauer/cuttlefish/issues/257

Currently an exception is thrown when you visit an address page for a blacklisted address for which the associated delivery is missing. It's probably missing because it was archived and removed from the database.

This bug prevents you from un-blacklisting a record at both the Address to view (`/addresses/test@oaf.org.au/to`) and BlackList index (`/black_lists`).

This PR adds a check for whether the associated delivery is present, and if it's not, it explains the situation to the user:

>  We don't know why this was blacklisted. The delivery that caused it may have been archived. 

![screen shot 2017-04-05 at 10 38 34 am](https://cloud.githubusercontent.com/assets/1239550/24685512/584df1ba-19f1-11e7-8434-ed45b8ad72fd.png)
![screen shot 2017-04-05 at 10 38 38 am](https://cloud.githubusercontent.com/assets/1239550/24685513/585355d8-19f1-11e7-9111-edf23640ea62.png)
