### PR TITLE
Rename rvm_io.ruby to rvm.ruby

### DIFF
--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -5,7 +5,7 @@
 - src: newrelic.newrelic-infra
   version: 0.3.0
 
-- src: rvm_io.ruby
+- src: rvm.ruby
   version: v2.0.1
 
 - src: geerlingguy.certbot


### PR DESCRIPTION
rvm_io.ruby is now rvm.ruby. Helps to fix some of the issues in #324 