### PR TITLE
Remove apm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,6 @@ gem "formtastic-bootstrap",
     ref: "f86eaef93bea0a06879b3977d7554864964a623f"
 gem "haml-coderay"
 gem "minitar"
-gem "newrelic_rpm"
 gem "nokogiri"
 gem "premailer"
 gem "pundit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,7 +278,6 @@ GEM
     net-ssh (5.0.2)
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
-    newrelic_rpm (5.2.0.345)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -519,7 +518,6 @@ DEPENDENCIES
   less-rails
   listen
   minitar
-  newrelic_rpm
   nokogiri
   pg
   premailer


### PR DESCRIPTION
Remove the NewRelic RPM/APM agent, but leave the newrelic-infra agent in place.

This feels a little heavy-handed as it means that downstream users will have to create a patch to add newrelic back in; but I couldn't see another simple way to do this.

https://docs.newrelic.com/docs/agents/manage-apm-agents/installation/disable-apm-agent confirms that this is the only supported method for permanently disabling APM. It's possible to quiesce *most* activity, but not all.