### PR TITLE
Add per app deny lists. Fixes #381

### DIFF
--- a/app/controllers/deny_lists_controller.rb
+++ b/app/controllers/deny_lists_controller.rb
@@ -6,14 +6,16 @@ class DenyListsController < ApplicationController
       params[:page] || 1,
       WillPaginate.per_page
     ) do |pager|
-      result = api_query limit: pager.per_page, offset: pager.offset
+      result = api_query limit: pager.per_page, offset: pager.offset, app_id: params[:app_id]
       pager.replace(result.data.blocked_addresses.nodes)
       pager.total_entries = result.data.blocked_addresses.total_count
+      @apps = result.data.apps
+      @app = @apps.find { |a| a.id == params[:app_id] } if params[:app_id]
     end
   end
 
   def destroy
-    result = api_query id: params[:id]
+    result = api_query id: params[:id], app_id: params[:app_id]
     blocked_address = result.data.remove_blocked_address.blocked_address
     if blocked_address
       flash[:notice] = "#{blocked_address.address} removed from deny list"

--- a/app/graphql/mutations/remove_blocked_address.rb
+++ b/app/graphql/mutations/remove_blocked_address.rb
@@ -7,14 +7,17 @@ module Mutations
              description:
                "The database ID of the blocked address you want to remove"
 
+    argument :app_id, ID,
+             required: false
+
     field :blocked_address, Types::BlockedAddress,
           null: true,
           description: "Returns the blocked address it successfully removed. " \
                        "Returns null otherwise."
 
-    def resolve(id:)
+    def resolve(id:, app_id: nil)
       destroy_blocked_address = DenyListServices::Destroy.call(
-        id: id, current_admin: context[:current_admin]
+        id: id, app_id: app_id, current_admin: context[:current_admin]
       )
       { blocked_address: destroy_blocked_address.result }
     end

--- a/app/models/app_deny_list.rb
+++ b/app/models/app_deny_list.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AppDenyList < ActiveRecord::Base
+  belongs_to :app
+  belongs_to :address
+  belongs_to :caused_by_delivery, class_name: "Delivery"
+
+  def caused_by_postfix_log_line
+    caused_by_delivery&.postfix_log_lines&.first
+  end
+end

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -30,7 +30,9 @@ class Delivery < ActiveRecord::Base
     # If there is no team there is no deny list
     # In concrete terms the internal cuttlefish app doesn't have a deny
     # list and isn't part of a team
-    app.team.nil? || email.ignore_deny_list || address.deny_lists.find_by(team_id: app.team.id).nil?
+    on_deny_list = !address.deny_lists.find_by(team_id: app.team.id).nil? ||
+                   !AppDenyList.find_by(app: app, address: address).nil?
+    app.team.nil? || email.ignore_deny_list || !on_deny_list
   end
 
   def add_open_event(request)

--- a/app/policies/app_deny_list_policy.rb
+++ b/app/policies/app_deny_list_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AppDenyListPolicy < ApplicationPolicy
+  def destroy?
+    app_ids = AppPolicy::Scope.new(user, App).resolve.pluck(:id)
+    app_ids.include?(record.app_id) && !Rails.configuration.cuttlefish_read_only_mode
+  end
+
+  class Scope < Scope
+    def resolve
+      app_ids = AppPolicy::Scope.new(user, App).resolve.pluck(:id)
+      scope.where(app_id: app_ids)
+    end
+  end
+end

--- a/app/services/deny_list_services/destroy.rb
+++ b/app/services/deny_list_services/destroy.rb
@@ -2,14 +2,15 @@
 
 module DenyListServices
   class Destroy < ApplicationService
-    def initialize(current_admin:, id:)
+    def initialize(current_admin:, id:, app_id:)
       super()
       @current_admin = current_admin
       @id = id
+      @app_id = app_id
     end
 
     def call
-      deny_list = DenyList.find(id)
+      deny_list = app_id ? AppDenyList.find(id) : DenyList.find(id)
       Pundit.authorize(current_admin, deny_list, :destroy?)
       deny_list.destroy!
       success!
@@ -18,6 +19,6 @@ module DenyListServices
 
     private
 
-    attr_reader :id, :current_admin
+    attr_reader :id, :app_id, :current_admin
   end
 end

--- a/app/services/postfix_log_line_services/create.rb
+++ b/app/services/postfix_log_line_services/create.rb
@@ -32,22 +32,14 @@ module PostfixLogLineServices
     end
 
     def add_to_deny_list(delivery)
-      # It is possible for the team_id to be nil if it's a mail from the
-      # cuttlefish "app" that is causing a hard bounce. For the time being
-      # let's just ignore those mails and not try to add them to the deny
-      # list because if we do they will cause an error
-      # TODO: Fix this properly. What's here now is just a temporary
-      # workaround
-      return if delivery.app.team_id.nil?
-
       # We don't want to save duplicates
-      return if DenyList.find_by(
-        team_id: delivery.app.team_id,
+      return if AppDenyList.find_by(
+        app: delivery.app,
         address: delivery.address
       )
 
-      DenyList.create(
-        team_id: delivery.app.team_id,
+      AppDenyList.create(
+        app: delivery.app,
         address: delivery.address,
         caused_by_delivery: delivery
       )

--- a/app/views/deny_lists/index.html.haml
+++ b/app/views/deny_lists/index.html.haml
@@ -3,6 +3,8 @@
   %p
     This list is auto-populated with any email addresses that bounce. Any further emails to addresses
     in this list will be "held back" and not sent.
+  %p
+    After one week addresses are automatically removed from this list
 
 
 = paginated_section @deny_lists, renderer: PagerRenderer, previous_label: image_tag("pager/previous.png", size: "13x14"), next_label: image_tag("pager/next.png", size: "13x14"), text: "Address" do

--- a/app/views/deny_lists/index.html.haml
+++ b/app/views/deny_lists/index.html.haml
@@ -6,6 +6,17 @@
   %p
     After one week addresses are automatically removed from this list
 
+.btn-group
+  %button.btn.dropdown-toggle(data-toggle="dropdown")
+    - if @app.nil?
+      Team list
+    - else
+      = @app.name
+    %span.caret
+  %ul.dropdown-menu
+    %li= link_to "Team list", deny_lists_path
+    - @apps.each do |app|
+      %li= link_to app.name, app_deny_lists_path(app.id)
 
 = paginated_section @deny_lists, renderer: PagerRenderer, previous_label: image_tag("pager/previous.png", size: "13x14"), next_label: image_tag("pager/next.png", size: "13x14"), text: "Address" do
   %p.count= page_entries_info @deny_lists, model: "deny listed email addresses"
@@ -30,4 +41,7 @@
                 = time_ago_in_words(deny_list.because_of_delivery_event.time)
                 ago
             %td
-              = button_to "Remove", deny_list_path(deny_list.id), method: :delete, class: "btn btn-danger"
+              - if @app
+                = button_to "Remove", app_deny_list_path(@app.id, deny_list.id), method: :delete, class: "btn btn-danger"
+              - else
+                = button_to "Remove", deny_list_path(deny_list.id), method: :delete, class: "btn btn-danger"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
   resources :apps do
     resources :emails, only: :index, as: :deliveries, controller: "deliveries"
     resources :clients, only: :index, as: :clients, controller: "clients"
+    resources :deny_lists, only: %i[index destroy], as: :deny_lists, controller: "deny_lists"
+
     member do
       get "dkim"
       get "webhook"

--- a/db/migrate/20200903034601_add_app_deny_lists.rb
+++ b/db/migrate/20200903034601_add_app_deny_lists.rb
@@ -1,0 +1,11 @@
+class AddAppDenyLists < ActiveRecord::Migration[5.2]
+  def change
+    create_table :app_deny_lists do |t|
+      t.references :address, null: false, foreign_key: true
+      t.references :caused_by_delivery, null: false, foreign_key: {to_table: :deliveries}
+      t.references :app, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_02_042840) do
+ActiveRecord::Schema.define(version: 2020_09_03_034601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,17 @@ ActiveRecord::Schema.define(version: 2020_09_02_042840) do
     t.index ["invited_by_id"], name: "index_admins_on_invited_by_id"
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
     t.index ["team_id"], name: "index_admins_on_team_id"
+  end
+
+  create_table "app_deny_lists", force: :cascade do |t|
+    t.bigint "address_id", null: false
+    t.bigint "caused_by_delivery_id", null: false
+    t.bigint "app_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["address_id"], name: "index_app_deny_lists_on_address_id"
+    t.index ["app_id"], name: "index_app_deny_lists_on_app_id"
+    t.index ["caused_by_delivery_id"], name: "index_app_deny_lists_on_caused_by_delivery_id"
   end
 
   create_table "apps", force: :cascade do |t|
@@ -185,6 +196,9 @@ ActiveRecord::Schema.define(version: 2020_09_02_042840) do
     t.datetime "updated_at"
   end
 
+  add_foreign_key "app_deny_lists", "addresses"
+  add_foreign_key "app_deny_lists", "apps"
+  add_foreign_key "app_deny_lists", "deliveries", column: "caused_by_delivery_id"
   add_foreign_key "emails", "addresses", column: "from_address_id", name: "emails_from_address_id_fk"
   add_foreign_key "emails", "apps", name: "emails_app_id_fk", on_delete: :cascade
   add_foreign_key "meta_values", "emails"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -207,8 +207,8 @@ delivery = email.deliveries.create!(address_id: address2.id, sent: true)
   delivery = email.deliveries.create!(address_id: to.id, sent: true)
 end
 
-# And add some bounced emails (caused by the first five emails)
-key_app.emails.limit(5).each do |e|
+# And add some bounced emails (caused by the first ten emails)
+key_app.emails.limit(10).each_with_index do |e, i|
   delivery = e.deliveries.first
   PostfixLogLine.create!(
     delivery_id: delivery.id,
@@ -221,9 +221,17 @@ key_app.emails.limit(5).each do |e|
     delay: "",
     delays: ""
   )
-  DenyList.create(
-    team_id: smart_team.id,
-    address: delivery.address,
-    caused_by_delivery: delivery
-  )
+  if i < 5
+    DenyList.create(
+      team_id: smart_team.id,
+      address: delivery.address,
+      caused_by_delivery: delivery
+    )
+  else
+    AppDenyList.create(
+      app_id: acting_app.id,
+      address: delivery.address,
+      caused_by_delivery: delivery
+    )
+  end
 end

--- a/lib/api/deny_lists/destroy.graphql
+++ b/lib/api/deny_lists/destroy.graphql
@@ -1,5 +1,5 @@
-mutation($id: ID!) {
-  removeBlockedAddress(id: $id) {
+mutation($appId: ID, $id: ID!) {
+  removeBlockedAddress(appId: $appId, id: $id) {
     blockedAddress {
       address
     }

--- a/lib/api/deny_lists/index.graphql
+++ b/lib/api/deny_lists/index.graphql
@@ -1,5 +1,5 @@
-query($limit: Int, $offset: Int) {
-  blockedAddresses(limit: $limit, offset: $offset) {
+query($appId: ID, $limit: Int, $offset: Int) {
+  blockedAddresses(appId: $appId, limit: $limit, offset: $offset) {
     totalCount
     nodes {
       id
@@ -12,5 +12,9 @@ query($limit: Int, $offset: Int) {
         }
       }
     }
+  }
+  apps {
+    id
+    name
   }
 }

--- a/lib/tasks/cuttlefish.rake
+++ b/lib/tasks/cuttlefish.rake
@@ -43,6 +43,10 @@ namespace :cuttlefish do
     old_items = DenyList.where("updated_at < ?", 1.week.ago)
     puts "Removing #{old_items.count} items from the deny list..."
     old_items.destroy_all
+
+    old_items = AppDenyList.where("updated_at < ?", 1.week.ago)
+    puts "Removing #{old_items.count} items from the deny list..."
+    old_items.destroy_all
   end
 
   desc "Archive all emails from a particular date (e.g. 2014-05-01)"

--- a/spec/services/deny_list_services/destroy_spec.rb
+++ b/spec/services/deny_list_services/destroy_spec.rb
@@ -8,7 +8,7 @@ describe DenyListServices::Destroy do
   let(:deny_list) { create(:deny_list, team: team) }
   let(:destroy_deny_list) do
     DenyListServices::Destroy.call(
-      current_admin: current_admin, id: deny_list.id
+      current_admin: current_admin, id: deny_list.id, app_id: nil
     )
   end
 

--- a/spec/services/postfix_log_line_services/create_spec.rb
+++ b/spec/services/postfix_log_line_services/create_spec.rb
@@ -78,11 +78,11 @@ describe PostfixLogLineServices::Create do
     it "should add the address to the deny list" do
       PostfixLogLineServices::Create.call(line)
 
-      expect(DenyList.count).to eq 1
-      d = DenyList.first
+      expect(AppDenyList.count).to eq 1
+      d = AppDenyList.first
       expect(d.address).to eq address
       expect(d.caused_by_delivery).to eq delivery
-      expect(d.team).to eq delivery.app.team
+      expect(d.app).to eq delivery.app
     end
 
     it "should not post the webhook because the url isn't set" do


### PR DESCRIPTION
After deploying and leaving this running for a week the main "team" deny list should be empty and the old deny lists can be removed from the code. This should be done to avoid confusion!