### PR TITLE
cleanup old deploys, fix deployment config, rotate rails app log files [Removed]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,8 @@ gem "acme-client"
 
 group :development do
   gem "capistrano", "~> 2"
+  gem "bcrypt_pbkdf", "~> 1.0"
+  gem "ed25519", "~> 1.2"
   gem "faker"
   gem "graphiql-rails"
   gem "rubocop", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     base64 (0.1.1)
     batch-loader (2.0.1)
     bcrypt (3.1.19)
+    bcrypt_pbkdf (1.1.2)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     builder (3.2.4)
@@ -156,6 +157,7 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    ed25519 (1.4.0)
     erubi (1.12.0)
     eventmachine (1.2.7)
     excon (0.100.0)
@@ -545,6 +547,7 @@ PLATFORMS
 DEPENDENCIES
   acme-client
   batch-loader
+  bcrypt_pbkdf (~> 1.0)
   bootstrap-sass (~> 2.0)
   capistrano (~> 2)
   capybara
@@ -557,6 +560,7 @@ DEPENDENCIES
   dkim
   dnsbl-client
   dotenv-rails
+  ed25519 (~> 1.2)
   eventmachine
   factory_bot_rails
   faker

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,7 +8,7 @@ require "honeybadger/capistrano" unless fetch(:local_deploy, false)
 
 set :application, "cuttlefish"
 set :repository,  "https://github.com/mlandauer/cuttlefish.git"
-set :rvm_ruby_string, :local
+set :rvm_ruby_string, File.read('.ruby-version').strip
 set :rvm_type, :system
 # The default for rvm_path is /usr/local/rvm
 set :rvm_path, "/usr/local/lib/rvm"
@@ -18,7 +18,8 @@ set :rvm_install_with_sudo, true
 if fetch(:local_deploy, false)
   server "localhost:2222", :app, :web, :db, primary: true
 else
-  server "li743-35.members.linode.com", :app, :web, :db, primary: true
+  # Linode ID: 771917, 8 GB at Fremont, CA, Created: 2014-12-11
+  server "23.239.22.35", :app, :web, :db, primary: true
 end
 
 set :use_sudo, false
@@ -26,6 +27,8 @@ set :deploy_via, :remote_cache
 
 set :user, "deploy"
 set :deploy_to, "/srv/www"
+
+set :keep_releases, 5
 
 # if you want to clean up old releases on each deploy uncomment this:
 # after "deploy:restart", "deploy:cleanup"

--- a/provisioning/roles/cuttlefish-postfix/meta/main.yml
+++ b/provisioning/roles/cuttlefish-postfix/meta/main.yml
@@ -136,3 +136,11 @@ dependencies:
           - sharedscripts
           - postrotate reload rsyslog >/dev/null 2>&1 || true
           - endscript
+      - name: production
+        path: "/srv/www/shared/log/*.log"
+        options:
+          - daily
+          - rotate 30
+          - compress
+          - missingok
+          - copytruncate


### PR DESCRIPTION
Cleanup old deploys, fix deployment config, rotate rails app log files

* Keep 5 releases (as long as cap deploy runs to the end),
* Change from non existent DNS (li743-35.members.linode.com) to IP address (23.239.22.35) for production server
  (DNS entry possibly disappeared when we added a reverse DNS entry)
* Use the ruby from .ruby-version not whatever your system happens to have as its system ruby!
* Enable use of ed2519 ssh keys with capistrano as I use them
* Add logrotate for /srv/www/shared/log/*.log (same as other servers)

*Installation*

The ansible playbook needs to be run to update the logrotate config (I have manually trimmed and rotated production.log and removed old logs from 2023, but the log is growing quickly)

When the next deployment is run, we need to check it removes the 6th oldest deployment (I have manually cleared all but 5 versions) see
* https://github.com/openaustralia/infrastructure/issues/335